### PR TITLE
Use browser cookies with yt-dlp for age-restricted content

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -19,7 +19,6 @@ FFMPEG_OPTS = {
     "before_options": "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5",
     "options": "-vn",
 }
-ytdl = yt_dlp.YoutubeDL(YTDL_OPTS)
 
 
 @dataclass
@@ -34,12 +33,16 @@ class MusicCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.queues: dict[int, list[Song]] = {}
+        self.music_cfg = bot.config.get("music", {})
+        opts = YTDL_OPTS.copy()
+        browser = self.music_cfg.get("cookies_browser")
+        if browser:
+            opts["cookiesfrombrowser"] = (browser,)
+        self.ytdl = yt_dlp.YoutubeDL(opts)
 
     # ---- Helpers ----
     def _has_dj_role(self, interaction: discord.Interaction) -> bool:
-        role_id: Optional[int] = (
-            self.bot.config.get("music", {}).get("dj_role_id")
-        )
+        role_id: Optional[int] = self.music_cfg.get("dj_role_id")
         return (
             role_id is None
             or role_id == 0
@@ -49,7 +52,7 @@ class MusicCog(commands.Cog):
     async def _create_source(self, url: str) -> Song:
         loop = asyncio.get_running_loop()
         data = await loop.run_in_executor(
-            None, lambda: ytdl.extract_info(url, download=False)
+            None, lambda: self.ytdl.extract_info(url, download=False)
         )
         if "entries" in data:
             data = data["entries"][0]

--- a/config.yaml
+++ b/config.yaml
@@ -31,7 +31,9 @@ permissions:
   channels:
     allowed_ids: []
     blocked_ids: []
-
+music:
+  dj_role_id:
+  cookies_browser:  # e.g., chrome or firefox for age-restricted videos
 
 # LLM settings:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ httpx
 openai
 pyyaml
 yt-dlp
+browser-cookie3
 PyNaCl
 ffmpeg


### PR DESCRIPTION
## Summary
- load browser cookies for yt-dlp when a `music.cookies_browser` is set
- add example `music` section in config for browser selection
- install `browser-cookie3` dependency

## Testing
- `python -m py_compile cogs/music.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689154babed4832ea52f0757159f5cd7