### PR TITLE
Fix unknown interaction when leaving voice channel

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -266,12 +266,14 @@ class MusicCog(commands.Cog):
                 ephemeral=True,
             )
             return
+        ephemeral = interaction.channel.type == discord.ChannelType.private
+        await interaction.response.defer(ephemeral=ephemeral, thinking=True)
         vc = interaction.guild.voice_client
         if vc:
             queue = await self._get_queue(interaction.guild_id)
             queue.clear()
             await vc.disconnect()
-            await self._safe_send(interaction, "Disconnected")
+            await self._safe_send(interaction, "Disconnected", ephemeral=ephemeral)
         else:
             await self._safe_send(
                 interaction,


### PR DESCRIPTION
## Summary
- defer `leave` command responses before disconnecting

## Testing
- `python -m py_compile cogs/music.py`

------
https://chatgpt.com/codex/tasks/task_b_68916b504d14832e99e621af97907020