### PR TITLE
Handle DRM links via Google and YouTube search

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -1,6 +1,7 @@
 import asyncio
 from dataclasses import dataclass
 from typing import Optional
+import logging
 
 import discord
 from discord import app_commands
@@ -117,13 +118,36 @@ class MusicCog(commands.Cog):
         await interaction.response.defer(ephemeral=ephemeral, thinking=True)
         try:
             song = await self._create_source(url)
-        except yt_dlp.utils.DownloadError:
-            await self._safe_send(
-                interaction,
-                "Could not process the provided URL (possibly DRM-protected or unsupported).",
-                ephemeral=ephemeral,
-            )
-            return
+        except yt_dlp.utils.DownloadError as exc:
+            google_key = self.bot.config.get("google_api_key")
+            google_cx = self.bot.config.get("google_cse_id")
+            fallback_song: Optional[Song] = None
+            if google_key and google_cx and "drm" in str(exc).lower():
+                try:
+                    resp = await self.bot.httpx_client.get(
+                        "https://www.googleapis.com/customsearch/v1",
+                        params=dict(q=url, num=1, key=google_key, cx=google_cx),
+                    )
+                    data = resp.json()
+                    items = data.get("items") or []
+                    if items:
+                        query_text = items[0].get("snippet") or items[0].get("title")
+                        if query_text:
+                            try:
+                                fallback_song = await self._create_source(f"ytsearch:{query_text}")
+                            except yt_dlp.utils.DownloadError:
+                                fallback_song = None
+                except Exception:
+                    logging.exception("Error searching for DRM-protected URL")
+            if fallback_song:
+                song = fallback_song
+            else:
+                await self._safe_send(
+                    interaction,
+                    "Could not process the provided URL (possibly DRM-protected or unsupported).",
+                    ephemeral=ephemeral,
+                )
+                return
         except discord.ClientException:
             await self._safe_send(
                 interaction,


### PR DESCRIPTION
## Summary
- add fallback for DRM-protected links
- query Google and use top result text to search YouTube via yt_dlp

## Testing
- `python -m py_compile cogs/music.py`


------
https://chatgpt.com/codex/tasks/task_b_68917c194034832eb6b508c132e0f4d1