### PR TITLE
feat: support multiple DJ roles

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -43,12 +43,20 @@ class MusicCog(commands.Cog):
 
     # ---- Helpers ----
     def _has_dj_role(self, interaction: discord.Interaction) -> bool:
-        role_id: Optional[int] = self.music_cfg.get("dj_role_id")
-        return (
-            role_id is None
-            or role_id == 0
-            or any(r.id == role_id for r in interaction.user.roles)
-        )
+        """Return True if the user has at least one configured DJ role.
+
+        The configuration now supports multiple role IDs under the
+        ``dj_role_ids`` key.  For backward compatibility a single
+        ``dj_role_id`` may also be provided.  If no role IDs are set or the
+        list is empty, no DJ role is required.
+        """
+        role_ids: Optional[list[int]] = self.music_cfg.get("dj_role_ids")
+        if role_ids is None:
+            role_id: Optional[int] = self.music_cfg.get("dj_role_id")
+            role_ids = [role_id] if role_id else []
+        if not role_ids:
+            return True
+        return any(r.id in role_ids for r in interaction.user.roles)
 
     async def _create_sources(self, url: str) -> list[Song]:
         loop = asyncio.get_running_loop()

--- a/config.yaml
+++ b/config.yaml
@@ -33,7 +33,9 @@ permissions:
     blocked_ids: []
 
 music:
-  dj_role_id: 1402073016476893284
+  # List of roles allowed to use music commands.
+  # Leave empty to allow everyone to control the player.
+  dj_role_ids: [1402073016476893284]
   cookies_browser: firefox
 # LLM settings:
 


### PR DESCRIPTION
## Summary
- allow configuration of multiple DJ roles
- add option to disable DJ role requirement

## Testing
- `python -m py_compile cogs/music.py`


------
https://chatgpt.com/codex/tasks/task_b_689188435228832e80776779885b7514