### PR TITLE
Improve voice connection reliability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py
+discord.py[voice]>=2.4.0
 httpx
 openai
 pyyaml


### PR DESCRIPTION
## Summary
- retry connecting to voice with exponential backoff and self-deafening
- pin discord.py with voice extras to a version that supports new voice gateway

## Testing
- `python -m py_compile cogs/music.py`


------
https://chatgpt.com/codex/tasks/task_b_689190f13980832e8696f6fdf1765abf