### PR TITLE
Add configurable Google credentials for ADC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Kuyari-Bot
+
+## Google Application Default Credentials
+
+The bot can authenticate with Google APIs by supplying Application Default Credentials (ADC).
+
+### Using your Google user account
+1. Install the [Google Cloud CLI](https://cloud.google.com/sdk/docs/install).
+2. Run `gcloud auth application-default login` and complete the sign‑in flow.
+3. The credentials are stored in your local ADC file and discovered automatically.
+
+### Using a service account key
+1. In the Google Cloud console, create a service account and grant the roles the bot needs.
+2. Generate a JSON key for the service account and download it.
+3. Set `google_credentials_file` in `config.yaml` to the path of that JSON key or set the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to that path before running the bot.
+4. Keep the key secure and rotate it regularly.
+
+The bot will load the file at startup and set `GOOGLE_APPLICATION_CREDENTIALS` so client libraries can authenticate automatically.

--- a/config.yaml
+++ b/config.yaml
@@ -4,9 +4,12 @@ bot_token:
 client_id: 
 status_message: Start Diggin In Yo Butt Twin 🥀🥀
 # … other keys …
-google_api_key: 
-google_cse_id: 
-openrouter_api_key: 
+google_api_key:
+google_cse_id:
+# Path to a service account JSON key used for Application Default Credentials
+# or leave blank to rely on gcloud auth
+google_credentials_file:
+openrouter_api_key:
 
 max_text: 100000
 max_images: 5

--- a/kuyaribot.py
+++ b/kuyaribot.py
@@ -7,6 +7,7 @@ import re
 from typing import Any, Literal, Optional
 
 from io import BytesIO
+import os
 import random
 import discord
 from discord.ext import commands
@@ -42,6 +43,8 @@ def get_config(filename: str = "config.yaml") -> dict[str, Any]:
 
 
 config = get_config()
+if (cred_file := config.get("google_credentials_file")) and "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = cred_file
 
 msg_nodes = {}
 last_task_time = 0


### PR DESCRIPTION
## Summary
- allow specifying a `google_credentials_file` in config
- set `GOOGLE_APPLICATION_CREDENTIALS` env var at startup for ADC
- document how to obtain and configure Google credentials

## Testing
- `python -m py_compile kuyaribot.py`


------
https://chatgpt.com/codex/tasks/task_b_6891cf7e70ec832eaf3deb0753dfd8fa