### PR TITLE
Handle timedelta from video intelligence responses

### DIFF
--- a/kuyaribot.py
+++ b/kuyaribot.py
@@ -244,19 +244,20 @@ async def analyze_video_labels_bytes(data: bytes) -> list[str]:
             }
         )
         result = operation.result(timeout=180)
+
+        def _seconds(duration: Any) -> float:
+            total = getattr(duration, "total_seconds", None)
+            if callable(total):
+                return total()
+            return duration.seconds + duration.nanos / 1e9
+
         labels: list[str] = []
         for segment_label in result.annotation_results[0].segment_label_annotations:
             if segment_label.segments:
                 segment = segment_label.segments[0]
                 confidence = segment.confidence
-                start = (
-                    segment.segment.start_time_offset.seconds
-                    + segment.segment.start_time_offset.nanos / 1e9
-                )
-                end = (
-                    segment.segment.end_time_offset.seconds
-                    + segment.segment.end_time_offset.nanos / 1e9
-                )
+                start = _seconds(segment.segment.start_time_offset)
+                end = _seconds(segment.segment.end_time_offset)
                 categories = ", ".join(
                     c.description for c in segment_label.category_entities
                 )


### PR DESCRIPTION
## Summary
- add a helper to convert video segment offsets to seconds
- compute start and end times using the helper to avoid AttributeError when offsets are `datetime.timedelta`

## Testing
- `python -m py_compile kuyaribot.py`


------
https://chatgpt.com/codex/tasks/task_b_6891e9f77ecc832e8de2d47516da75d3