### PR TITLE
Enable guild message processing

### DIFF
--- a/kuyaribot.py
+++ b/kuyaribot.py
@@ -49,7 +49,7 @@ if (cred_file := config.get("google_credentials_file")) and "GOOGLE_APPLICATION_
 msg_nodes = {}
 last_task_time = 0
 
-intents = discord.Intents.default()
+intents = discord.Intents.all()
 intents.message_content = True
 activity = discord.CustomActivity(name=(config["status_message"] or "github.com/kylapro/Kuyari-Bot")[:128])
 discord_bot = commands.Bot(intents=intents, activity=activity, command_prefix=None)
@@ -364,10 +364,12 @@ async def on_ready() -> None:
 async def on_message(new_msg: discord.Message) -> None:
     global last_task_time
 
-    is_dm = new_msg.channel.type == discord.ChannelType.private
-
     if new_msg.author.bot:
         return
+
+    await discord_bot.process_commands(new_msg)
+
+    is_dm = new_msg.channel.type == discord.ChannelType.private
 
     should_respond_passively = False
     if not is_dm and discord_bot.user not in new_msg.mentions:


### PR DESCRIPTION
## Summary
- request all intents so the bot can receive guild messages
- process commands for each incoming message

## Testing
- `python -m py_compile kuyaribot.py`


------
https://chatgpt.com/codex/tasks/task_b_6891f2c2e960832e8dbebf779a1e89cb