### PR TITLE
Enable voice state intent for stable voice connections

### DIFF
--- a/kuyaribot.py
+++ b/kuyaribot.py
@@ -47,6 +47,7 @@ last_task_time = 0
 
 intents = discord.Intents.default()
 intents.message_content = True
+intents.voice_states = True
 activity = discord.CustomActivity(name=(config["status_message"] or "github.com/kylapro/Kuyari-Bot")[:128])
 discord_bot = commands.Bot(intents=intents, activity=activity, command_prefix=None)
 


### PR DESCRIPTION
## Summary
- Explicitly enable the voice_states intent so the bot can join voice channels reliably

## Testing
- `python -m py_compile kuyaribot.py`


------
https://chatgpt.com/codex/tasks/task_b_6899255e3568832e84c047347f0bea30