### PR TITLE
Ensure bot self-deafens and uses move_to for voice connections

### DIFF
--- a/cogs/music.py
+++ b/cogs/music.py
@@ -150,10 +150,15 @@ class MusicCog(commands.Cog):
         voice = interaction.guild.voice_client
         try:
             if voice and voice.channel != channel:
-                await voice.disconnect(force=True)
-                voice = await channel.connect(reconnect=True, timeout=60)
+                await voice.move_to(channel, timeout=60)
+                # Ensure the bot is always self-deafened when moving channels
+                await interaction.guild.change_voice_state(
+                    channel=channel, self_deaf=True, self_mute=False
+                )
             elif not voice:
-                voice = await channel.connect(reconnect=True, timeout=60)
+                voice = await channel.connect(
+                    reconnect=True, timeout=60, self_deaf=True
+                )
         except asyncio.TimeoutError:
             await self._safe_send(
                 interaction,


### PR DESCRIPTION
## Summary
- Use `VoiceClient.move_to` instead of full disconnects when switching channels
- Self-deafen the bot on connect or channel move to improve voice stability

## Testing
- `python -m py_compile cogs/music.py`


------
https://chatgpt.com/codex/tasks/task_b_68993624229c832e80b0ddefc8e8b87e