### PR TITLE
Prefix messages with speaker name

### DIFF
--- a/kuyaribot.py
+++ b/kuyaribot.py
@@ -432,9 +432,13 @@ async def on_message(new_msg: discord.Message) -> None:
                     curr_node.fetch_parent_failed = True
 
             text_for_model = curr_node.text or ""
-            if curr_node.role == "user":
-                author_name = getattr(curr_msg.author, "display_name", None) or str(curr_node.user_id or "Unknown")
-                text_for_model = f"{author_name}: {text_for_model}" if text_for_model else f"{author_name}:"
+            if curr_node.role in ("user", "assistant"):
+                author_name = getattr(curr_msg.author, "display_name", None) or str(
+                    curr_node.user_id or getattr(curr_msg.author, "id", "Unknown")
+                )
+                text_for_model = (
+                    f"{author_name}: {text_for_model}" if text_for_model else f"{author_name}:"
+                )
             text_for_model = text_for_model[:max_text]
 
             if curr_node.images[:max_images]:


### PR DESCRIPTION
## Summary
- Prefix both user and assistant messages with the sender's display name before sending to the LLM

## Testing
- `python -m py_compile kuyaribot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0327c3e18832ea608c13173b73540